### PR TITLE
fix indirect jmp resolve indirect twice.

### DIFF
--- a/lib/r6502/cpu_instructions.rb
+++ b/lib/r6502/cpu_instructions.rb
@@ -330,14 +330,7 @@ module R6502
       inc_pc_by_mode(mode)
     end
     def jmp(arg, mode)
-      case mode
-      when :abs
-        @pc = arg
-      else #indirect
-        lsb = @mem.get( arg )
-        msb = @mem.get( arg + 1)
-        @pc = lsb + msb<<8
-      end
+      @pc = arg
     end
     def lda(arg, mode)
       case mode

--- a/spec/r6502/cpu_instructions_spec.rb
+++ b/spec/r6502/cpu_instructions_spec.rb
@@ -983,10 +983,8 @@ module R6502
       @cpu.pc.should == 0x2000
 
       @cpu.pc = 0x1000
-      @mem.set( 0x2000, 0x00 )
-      @mem.set( 0x2001, 0x11 )
       @cpu.jmp(0x2000, :ind)
-      @cpu.pc.should == 0x1100
+      @cpu.pc.should == 0x2000
     end
     it "jsr" do
       @cpu.s = 0xff


### PR DESCRIPTION
Repost from #3, `* Indirect jump (etc. "jmp (addr)")`

> It looks like you're making indirect jump behave   exactly the same as direct jump? And I think I have the behavior correct for indirect,y addressing.

It's seems resolving indirect access **twice**, in `decode_arg()` and `jmp()`.
so `jmp (arg)` must jump to `*arg`, but jump to `**arg`.

I'm not sure where I should resolve indirect access in `decode_arg()` and `jump()`.
How do you think? 

---

example code

```
lda #$34
sta $1000
lda #$12
sta $1001
jmp ($1000)
```

must jump to $1234, but $0000  ( == `*($1234)` )
