### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Update: 9 April 2014
-At the [suggestion](https://github.com/joelanders/r6502/issues/1) of Mike Nabreezy,
+At the [suggestion](https://github.com/joelanders/r6502/issues/1) of Ed Spittles,
 I've pulled in [some tests from Klaus Dormann](https://github.com/Klaus2m5/6502_65C02_functional_tests).
 Specifically, I've copied his `6502_functional_test`
 binary and listing to my `bin/` directory here.


### PR DESCRIPTION
Adding Klaus Dormann's test suite was suggested by Ed Spittles (@biged) in #1.  

I agree with Ed that it's a good idea.
